### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/graphqldb/adapter.py
+++ b/graphqldb/adapter.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypedDict,
     Union,
     cast,
 )
@@ -30,7 +31,6 @@ from shillelagh.fields import (
 from shillelagh.typing import RequestedOrder
 
 from .lib import get_last_query, run_query
-from .types import TypedDict
 
 # -----------------------------------------------------------------------------
 

--- a/graphqldb/types.py
+++ b/graphqldb/types.py
@@ -1,6 +1,0 @@
-import sys
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:  # pragma: no cover
-    from typing_extensions import TypedDict  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']
 exclude = '''
 (
   /(

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,2 @@
 requests
 shillelagh
-typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ sqlalchemy==1.4.42
     # via shillelagh
 typing-extensions==4.6.3
     # via
-    #   -r requirements.in
     #   shillelagh
 urllib3==2.0.3
     # via requests

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,6 @@ setup(
     install_requires=(
         "shillelagh >= 1.2.0",
         "requests >= 2.31.0",
-        "typing-extensions",
     ),
     license="MIT",
     classifiers=[
@@ -121,7 +120,6 @@ setup(
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Closes: https://github.com/cancan101/graphql-db-api/issues/271